### PR TITLE
Ensure php::module::ini uses the parametrised package name

### DIFF
--- a/manifests/module/ini.pp
+++ b/manifests/module/ini.pp
@@ -26,8 +26,8 @@ define php::module::ini (
 
   # Package name
   $rpmpkgname = $pkgname ? {
-    false   => "php-${title}",
-    default => "php-${pkgname}",
+    false   => "${php::params::php_package_name}-${title}",
+    default => "${php::params::php_package_name}-${pkgname}",
   }
 
   # INI configuration file


### PR DESCRIPTION
Fixes an issue where changing the `php_package_name` would cause `php::module::ini` to require a different (missing) package to the one setup by `php::module`
