### PR TITLE
php.ini file template can be declared on the object.

### DIFF
--- a/manifests/ini.pp
+++ b/manifests/ini.pp
@@ -12,6 +12,7 @@
 #  }
 #
 define php::ini (
+  $template                   = 'php/php.ini-el6.erb',
   # php.ini options in the order they appear in the original file
   $user_ini_filename          = '.user.ini',
   $user_ini_cache_ttl         = '300',
@@ -104,7 +105,7 @@ define php::ini (
 ) {
   include php::common
   file { $title:
-    content => template('php/php.ini-el6.erb'),
+    content => template($template),
   }
 }
 


### PR DESCRIPTION
To support different OS's I need to be able to override the el6 php.ini file with my own.
