### PR TITLE
Manage the incorrect named php-apc package under Debian.

### DIFF
--- a/manifests/module.pp
+++ b/manifests/module.pp
@@ -11,7 +11,14 @@
 define php::module ( $ensure = installed ) {
   require php::params
 
-  package { "${php::params::php_package_name}-${title}":
+  # Manage the incorrect named php-apc package under Debians
+  if ($title == 'apc') {
+    $package = $php::params::php_apc_package_name
+  } else { 
+    $package = "${php::params::php_package_name}-${title}"
+  }
+  
+  package { $package:
     ensure => $ensure,
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -2,6 +2,7 @@ class php::params {
   case $::osfamily {
     'Debian': {
       $php_package_name = 'php5'
+      $php_apc_package_name = 'php-apc'
       $common_package_name = 'php5-common'
       $cli_package_name = 'php5-cli'
       $php_conf_dir = '/etc/php5/conf.d'
@@ -18,6 +19,7 @@ class php::params {
 
     default: {
       $php_package_name = 'php'
+      $php_apc_package_name = 'php-apc'
       $common_package_name = 'php-common'
       $cli_package_name = 'php-cli'
       $php_conf_dir = '/etc/php.d'


### PR DESCRIPTION
Hi,

The php apc module should be named php5-apc on Debian. Unfortunately it's named php-apc.

I've modified the module to handle this exception.

Jeroen
