### PR TITLE
Fix the regsubst flag

### DIFF
--- a/manifests/module/ini.pp
+++ b/manifests/module/ini.pp
@@ -22,7 +22,7 @@ define php::module::ini (
 ) {
 
   # Strip 'pecl-*' prefix is present, since .ini files don't have it
-  $modname = regsubst($title , '^pecl-', '', G)
+  $modname = regsubst($title , '^pecl-', '', 'G')
 
   
   # Handle naming issue of php-apc package on Debian


### PR DESCRIPTION
When parser = future is enabled in puppet.conf, it doesn't like unqouted flag for regsubst. The new parser will throw out "Error 400 on SERVER: regsubst(): bad flag `g' at /etc/puppet/modules/common/php/manifests/module/ini.pp:25" error. Adding the qoute fixs the problem.
