### PR TITLE
Allow specifying the "ensure" parameter in all calls to"package"

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,14 @@ Create `php.ini` files for different uses, but based on the same template :
       require => Package['httpd'],
     }
 
-Install the PHP command line interface :
+Install the latest version of the PHP command line interface in your OS's
+package manager (e.g. Yum for RHEL):
 
     include php::cli
+
+Install version 5.3.3 of the PHP command line interface ::
+
+    class { 'php::cli': ensure => '5.3.3' }
 
 Install the PHP Apache httpd module, using its own php configuration file
 (you will need mod_env in apache for this to work) :

--- a/manifests/cli.pp
+++ b/manifests/cli.pp
@@ -7,10 +7,11 @@
 #  include php::cli
 #
 class php::cli(
-  $inifile = '/etc/php.ini'
+  $inifile = '/etc/php.ini',
+  $ensure = 'installed',
 ) inherits php::params {
   package { $cli_package_name:
-    ensure  => installed,
+    ensure  => $ensure,
     require => File[$inifile],
   }
 }

--- a/manifests/fpm/daemon.pp
+++ b/manifests/fpm/daemon.pp
@@ -22,14 +22,9 @@ class php::fpm::daemon (
     default => $log_group,
   }
 
-  if ( $ensure == 'absent' ) {
+  package { $fpm_package_name: ensure => $ensure }
 
-    package { $fpm_package_name: ensure => absent }
-
-  } else {
-
-    package { $fpm_package_name: ensure => installed }
-
+  if ( $ensure != 'absent' ) {
     service { $fpm_service_name:
       ensure    => running,
       enable    => true,

--- a/manifests/mod_php5.pp
+++ b/manifests/mod_php5.pp
@@ -7,9 +7,12 @@
 #  php::ini { '/etc/php-httpd.ini': }
 #  class { 'php::mod_php5': inifile => '/etc/php-httpd.ini' }
 #
-class php::mod_php5 ( $inifile = '/etc/php.ini' ) inherits php::params {
+class php::mod_php5 (
+  $inifile = '/etc/php.ini',
+  $ensure = 'installed',
+) inherits php::params {
   package { $php_package_name:
-    ensure  => installed,
+    ensure  => $ensure,
     require => File[$inifile],
     notify  => Service[$httpd_service_name],
   }


### PR DESCRIPTION
This allows installing a specific version of PHP by passing a version string for "ensure", e.g. ensure => "5.3.3"

This is backwards-compatible, with the possible exception of the change to the php::fpm::daemon class: the $ensure parameter will now be passed straight to "package" instead of using one of "installed" or "absent". The default value for $ensure in php::fpm::daemon is "present", which I'm pretty sure is the same as "installed" for all the package providers.
