### PR TITLE
Added in support for php-memcache in a similar way php-apc is supported.

### DIFF
--- a/manifests/module.pp
+++ b/manifests/module.pp
@@ -14,9 +14,15 @@ define php::module (
 
   include '::php::params'
 
-  # Manage the incorrect named php-apc package under Debians
+  # Manage the incorrect named php-apc and memcache(d) packages under Debians
   if ($title == 'apc') {
     $package = $php::params::php_apc_package_name
+  } elsif ($title == 'memcache') {
+    # Package name
+    $package = $php::params::php_memcache_package_name
+  } elsif ($title == 'memcached') {
+    # Package name
+    $package = $php::params::php_memcached_package_name
   } else { 
     $package = "${php::params::php_package_name}-${title}"
   }

--- a/manifests/module/ini.pp
+++ b/manifests/module/ini.pp
@@ -24,10 +24,16 @@ define php::module::ini (
   # Strip 'pecl-*' prefix is present, since .ini files don't have it
   $modname = regsubst($title , '^pecl-', '', 'G')
 
-  # Handle naming issue of php-apc package on Debian
+  # Handle naming issue of php-apc and php-memcache(d) packages on Debian
   if ($modname == 'apc') {
     # Package name
     $rpmpkgname = $php::params::php_apc_package_name
+  } elsif ($modname == 'memcache') {
+    # Package name
+    $rpmpkgname = $php::params::php_memcache_package_name
+  } elsif ($modname == 'memcached') {
+    # Package name
+    $rpmpkgname = $php::params::php_memcached_package_name
   } else {
     # Package name
     $rpmpkgname = $pkgname ? {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,6 +3,8 @@ class php::params {
     'Debian': {
       $php_package_name = 'php5'
       $php_apc_package_name = 'php-apc'
+      $php_memcache_package_name = 'php5-memcache'
+      $php_memcached_package_name = 'php5-memcached'
       $common_package_name = 'php5-common'
       $cli_package_name = 'php5-cli'
       $php_conf_dir = '/etc/php5/conf.d'
@@ -19,6 +21,8 @@ class php::params {
     default: {
       $php_package_name = 'php'
       $php_apc_package_name = 'php-pecl-apc'
+      $php_memcache_package_name = 'php-pecl-memcache'
+      $php_memcached_package_name = 'php-pecl-memcached'
       $common_package_name = 'php-common'
       $cli_package_name = 'php-cli'
       $php_conf_dir = '/etc/php.d'


### PR DESCRIPTION
When attempting to install the memcache and memcached PHP modules through the puppet-php module, the naming differs just enough that they cannot be located. This patch aims to provide support for php memcache(d) in the same way that apc is supported.
