### PR TITLE
Adding if statement to templates/fpm/pool.conf.erb

### DIFF
--- a/templates/fpm/pool.conf.erb
+++ b/templates/fpm/pool.conf.erb
@@ -12,7 +12,11 @@ listen.backlog = <%= @listen_backlog %>
 ; must be separated by a comma. If this value is left blank, connections will be
 ; accepted from any ip address.
 ; Default Value: any
+<% if @listen_allowed_clients == 'any' -%>
+;listen.allowed_clients =
+<% else -%>
 listen.allowed_clients = <%= @listen_allowed_clients %>
+<% end -%>
 
 ; Set permissions for unix socket, if one is used. In Linux, read/write
 ; permissions must be set in order to allow connections from a web server. Many


### PR DESCRIPTION
Hi, I've added an if statement to pool.conf.erb that checks to see if listen_allowed_clients is set to any.  If so, it will add a commented listen.allowed_clients.  Otherwise, add the original line.  This is the only way I've been able to make php-fpm actually allow any client.  Php-fpm fails if it is set to nothing or 0.0.0.0.

Thanks,
Damon
