### PR TITLE
Added process.priority

### DIFF
--- a/manifests/fpm/conf.pp
+++ b/manifests/fpm/conf.pp
@@ -35,6 +35,7 @@ define php::fpm::conf (
   $pm_status_path            = undef,
   $ping_path                 = undef,
   $ping_response             = 'pong',
+  $process_priority          = undef,
   $request_terminate_timeout = '0',
   $request_slowlog_timeout   = '0',
   $slowlog                   = "/var/log/php-fpm/${name}-slow.log",

--- a/templates/fpm/pool.conf.erb
+++ b/templates/fpm/pool.conf.erb
@@ -151,6 +151,17 @@ ping.path = <%= @ping_path %>
 ; response is formatted as text/plain with a 200 response code.
 ; Default Value: pong
 ping.response = <%= @ping_response %>
+
+; Specify the nice(2) priority to apply to the master process (only if set)
+; The value can vary from -19 (highest priority) to 20 (lower priority)
+; Note: - It will only work if the FPM master process is launched as root
+;       - The pool process will inherit the master process priority
+;         unless it specified otherwise
+<% if @process_priority -%>
+process.priority = <%= @process_priority %>
+<% else -%>
+; Default Value: no set
+<% end -%>
  
 ; The timeout for serving a single request after which the worker process will
 ; be killed. This option should be used when the 'max_execution_time' ini option


### PR DESCRIPTION
You may now set a priority on a pool. With this feature you may have one low priority pool for background processes and a other pool with normal priority for your webpage visitors. 

Here is a link to that feature request: https://bugs.php.net/bug.php?id=62160

This was added in PHP 5.4.4 if I'm not mistaken. 
