### PR TITLE
Fixed bug with the process priority

### DIFF
--- a/manifests/fpm/conf.pp
+++ b/manifests/fpm/conf.pp
@@ -26,7 +26,7 @@ define php::fpm::conf (
   $listen_group              = undef,
   $listen_mode               = undef,
   $listen_allowed_clients    = '127.0.0.1',
-  $priority                  = undef,
+  $process_priority          = undef,
   $pm                        = 'dynamic',
   $pm_max_children           = '50',
   $pm_start_servers          = '5',

--- a/templates/fpm/pool.conf.erb
+++ b/templates/fpm/pool.conf.erb
@@ -59,10 +59,10 @@ listen.allowed_clients = <%= @listen_allowed_clients %>
 ; - The pool processes will inherit the master process priority
 ; unless it specified otherwise
 ; Default Value: no set
-<% if @priority -%>
-priority = <%= @priority %>
+<% if @process_priority -%>
+process.priority = <%= @process_priority %>
 <% else -%>
-; priority = -19
+; process.priority = -19
 <% end -%>
 
 ; Choose how the process manager will control the number of child processes.


### PR DESCRIPTION
I've created this PR as a follow up after #25. There was a problem when PR #25 was manually merged. The setting $process_priority should be a setting for each PHP-FPM pool. Not the daemon. 

Consider using Githubs merge function to avoid these kind of errors in the future. 
