### PR TITLE
Allow override of php-common package name

### DIFF
--- a/manifests/common.pp
+++ b/manifests/common.pp
@@ -5,6 +5,8 @@
 #
 # We can't use a virtual resource, since we have no central place to put it.
 #
-class php::common inherits ::php::params {
+class php::common (
+  $common_package_name = $::php::params::common_package_name,
+) inherits ::php::params {
   package { $common_package_name: ensure => 'installed' }
 }


### PR DESCRIPTION
Similar to #20, I'd like to be able to override $common_package_name. This is useful for e.g. using IUS PHP where the common package name will vary based on PHP version ("php53u-common", "php54-common")
