### PR TITLE
Allow override of php_package_name in mod_php5 class

### DIFF
--- a/manifests/mod_php5.pp
+++ b/manifests/mod_php5.pp
@@ -8,8 +8,9 @@
 #  class { 'php::mod_php5': inifile => '/etc/php-httpd.ini' }
 #
 class php::mod_php5 (
-  $ensure  = 'installed',
-  $inifile = '/etc/php.ini',
+  $ensure           = 'installed',
+  $inifile          = '/etc/php.ini',
+  $php_package_name = $::php::params::php_package_name,
 ) inherits ::php::params {
 
   package { $php_package_name:


### PR DESCRIPTION
This is the last class that needs to be modified in order to allow package names to be overridden in class parameters.

I'm still considering a way to handle this globally for all the php:: classes, but it's not going to be simple, and I'd love to have a working release with these parameters in place while we consider that.

Thanks!