### PR TITLE
uncomment user_ini.cache_ttl option

### DIFF
--- a/templates/php.ini-el6.erb
+++ b/templates/php.ini-el6.erb
@@ -204,7 +204,7 @@ user_ini.filename = "<%= @user_ini_filename %>"
 ;user_ini.filename =
 
 ; TTL for user-defined php.ini files (time-to-live) in seconds. Default is 300 seconds (5 minutes)
-;user_ini.cache_ttl = <%= @user_ini_cache_ttl %>
+user_ini.cache_ttl = <%= @user_ini_cache_ttl %>
 
 ;;;;;;;;;;;;;;;;;;;;
 ; Language Options ;


### PR DESCRIPTION
This doesn't look like it's supposed to be commented out.
