### PR TITLE
notify fpm service if an .ini file changed or php module installed

### DIFF
--- a/manifests/ini.pp
+++ b/manifests/ini.pp
@@ -114,5 +114,9 @@ define php::ini (
     content => template($template),
   }
 
+  #notify fpm daemon to reload if loaded and $title file changed
+  if defined ('::php::fpm::daemon') {
+    File [$title] ~> Service[$php::params::fpm_service_name]
+  }
 }
 

--- a/manifests/module.pp
+++ b/manifests/module.pp
@@ -28,5 +28,11 @@ define php::module (
   package { $package:
     ensure => $ensure,
   }
+  
+  #notify fpm daemon to reload if loaded and $title file changed
+  if defined ('::php::fpm::daemon') {
+    Package [$package] ~> Service[$php::params::fpm_service_name]
+  }
+
 }
 

--- a/manifests/module/ini.pp
+++ b/manifests/module/ini.pp
@@ -53,5 +53,10 @@ define php::module::ini (
     }
   }
 
+  # notify fpm daemon to reload if loaded and php module ini file changed
+  if defined ('::php::fpm::daemon') {
+    File ["${::php::params::php_conf_dir}/${modname}.ini"] ~> Service[$php::params::fpm_service_name]
+  }
+
 }
 


### PR DESCRIPTION
notify the fpm service => reload if there are changes to:
- php.ini's 
- modules (installed, removed)
- modules .ini files 

for example if you install the module "ldap" - this will now results in:

Notice: /Stage[main]/Website::Typo3/Php::Module[ldap]/Package[php5-ldap]/ensure: ensure changed 'purged' to 'present'
Info: /Package[php5-ldap]: Scheduling refresh of Service[php5-fpm]

and the module is immediately loaded - otherwise you have to reload the fpm deamon manually (nobody wants that..)
