### PR TITLE
Conditionally declare packages

### DIFF
--- a/manifests/cli.pp
+++ b/manifests/cli.pp
@@ -11,9 +11,11 @@ class php::cli (
   $inifile          = '/etc/php.ini',
   $cli_package_name = $::php::params::cli_package_name,
 ) inherits ::php::params {
-  package { $cli_package_name:
-    ensure  => $ensure,
-    require => File[$inifile],
+  if !defined(Package[$cli_package_name]) {
+    package { $cli_package_name:
+      ensure  => $ensure,
+      require => File[$inifile],
+    }
   }
 }
 

--- a/manifests/common.pp
+++ b/manifests/common.pp
@@ -8,5 +8,7 @@
 class php::common (
   $common_package_name = $::php::params::common_package_name,
 ) inherits ::php::params {
-  package { $common_package_name: ensure => 'installed' }
+  if !defined(Package[$common_package_name]) {
+    package { $common_package_name: ensure => 'installed' }
+  }
 }

--- a/manifests/fpm/daemon.pp
+++ b/manifests/fpm/daemon.pp
@@ -25,7 +25,9 @@ class php::fpm::daemon (
     default => $log_group,
   }
 
-  package { $fpm_package_name: ensure => $ensure }
+  if !defined(Package[$fpm_package_name]) {
+    package { $fpm_package_name: ensure => $ensure }
+  }
 
   if ( $ensure != 'absent' ) {
     service { $fpm_service_name:


### PR DESCRIPTION
To avoid potential "duplicate resource definitions", wrap package declarations in a conditional block.
