### PR TITLE
Allow the `php-fpm` service name to be configured

### DIFF
--- a/manifests/fpm/conf.pp
+++ b/manifests/fpm/conf.pp
@@ -17,7 +17,8 @@
 #
 define php::fpm::conf (
   $ensure                    = 'present',
-  $fpm_package_name          = undef,
+  $fpm_package_name          = $::php::params::fpm_package_name,
+  fpm_service_name           = $::php::params::fpm_service_name,
   $user                      = 'apache',
   $group                     = undef,
   $listen                    = '127.0.0.1:9000',
@@ -65,28 +66,23 @@ define php::fpm::conf (
   # Hack-ish to default to user for group too
   $group_final = $group ? { undef => $user, default => $group }
 
-  $fpm_package_name_final = $fpm_package_name ? {
-    undef   => $::php::params::fpm_package_name,
-    default => $fpm_package_name,
-  }
-
   if ( $ensure == 'absent' ) {
 
     file { "${php::params::fpm_pool_dir}/${pool}.conf":
-      notify  => Service[$php::params::fpm_service_name],
+      notify  => Service[$fpm_service_name],
       ensure  => absent,
-      require => Package[$fpm_package_name_final],
+      require => Package[$fpm_package_name],
     }
 
   } else {
 
     file { "${php::params::fpm_pool_dir}/${pool}.conf":
-      notify  => Service[$php::params::fpm_service_name],
+      notify  => Service[$fpm_service_name],
       content => template('php/fpm/pool.conf.erb'),
       owner   => 'root',
       group   => 'root',
       mode    => '0644',
-      require => Package[$fpm_package_name_final],
+      require => Package[$fpm_package_name],
     }
 
   }

--- a/manifests/fpm/daemon.pp
+++ b/manifests/fpm/daemon.pp
@@ -8,6 +8,7 @@
 class php::fpm::daemon (
   $ensure                      = 'present',
   $fpm_package_name            = $::php::params::fpm_package_name,
+  $fpm_service_name            = $::php::params::fpm_service_name,
   $log_level                   = 'notice',
   $emergency_restart_threshold = '0',
   $emergency_restart_interval  = '0',


### PR DESCRIPTION
Currently, the package name for `php-fpm` can be configured but the service name cannot.