### PR TITLE
Create a entry point class and enable customized php name

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ change everything in ways which are typical for RHEL, but it also works on
 Debian based distributions (such as Ubuntu), and support for others should
 be easy to add.
 
+* `php` : The entry point of the module
 * `php::cli` : Simple class to install PHP's Command Line Interface
 * `php::fpm::daemon` : Simple class to install PHP's FastCGI Process Manager
 * `php::fpm::conf` : PHP FPM pool configuration definition
@@ -19,6 +20,10 @@ be easy to add.
 * `php::module::ini` : Definition to manage the ini files of separate modules
 
 ## Examples
+
+Declaring the `php` class
+
+    include php
 
 Create `php.ini` files for different uses, but based on the same template :
 

--- a/manifests/cli.pp
+++ b/manifests/cli.pp
@@ -9,8 +9,8 @@
 class php::cli (
   $ensure           = 'installed',
   $inifile          = '/etc/php.ini',
-  $cli_package_name = $::php::params::cli_package_name,
 ) inherits ::php::params {
+  $cli_package_name = "${::php::php_name}${::php::params::cli_package_suffix}"
   package { $cli_package_name:
     ensure  => $ensure,
     require => File[$inifile],

--- a/manifests/common.pp
+++ b/manifests/common.pp
@@ -6,7 +6,7 @@
 # We can't use a virtual resource, since we have no central place to put it.
 #
 class php::common (
-  $common_package_name = $::php::params::common_package_name,
 ) inherits ::php::params {
+  $common_package_name = "${::php::php_name}${::php::params::common_package_suffix}"
   package { $common_package_name: ensure => 'installed' }
 }

--- a/manifests/fpm/conf.pp
+++ b/manifests/fpm/conf.pp
@@ -66,7 +66,7 @@ define php::fpm::conf (
   $group_final = $group ? { undef => $user, default => $group }
 
   $fpm_package_name_final = $fpm_package_name ? {
-    undef   => $::php::params::fpm_package_name,
+    undef   => $::php::fpm::daemon::fpm_package_name,
     default => $fpm_package_name,
   }
 

--- a/manifests/fpm/daemon.pp
+++ b/manifests/fpm/daemon.pp
@@ -7,7 +7,6 @@
 #
 class php::fpm::daemon (
   $ensure                      = 'present',
-  $fpm_package_name            = $::php::params::fpm_package_name,
   $log_level                   = 'notice',
   $emergency_restart_threshold = '0',
   $emergency_restart_interval  = '0',
@@ -18,6 +17,7 @@ class php::fpm::daemon (
   $log_group                   = false,
   $log_dir_mode                = '0770',
 ) inherits ::php::params {
+  $fpm_package_name = "${::php::php_name}-fpm"
 
   # Hack-ish to default to user for group too
   $log_group_final = $log_group ? {

--- a/manifests/ini.pp
+++ b/manifests/ini.pp
@@ -106,13 +106,9 @@ define php::ini (
   $soap_wsdl_cache_dir        = '/tmp',
   $soap_wsdl_cache_ttl        = '86400',
 ) {
-
-  include '::php::common'
-
   file { $title:
     ensure  => $ensure,
     content => template($template),
   }
-
 }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,0 +1,4 @@
+class php (
+  $php_name = $::php::params::php_package_name,
+) inherits ::php::params {
+}

--- a/manifests/mod_php5.pp
+++ b/manifests/mod_php5.pp
@@ -12,7 +12,7 @@ class php::mod_php5 (
   $inifile = '/etc/php.ini',
 ) inherits ::php::params {
 
-  package { $php_package_name:
+  package { $::php::php_name:
     ensure  => $ensure,
     require => File[$inifile],
     notify  => Service[$httpd_service_name],

--- a/manifests/module.pp
+++ b/manifests/module.pp
@@ -16,12 +16,12 @@ define php::module (
 
   # Manage the incorrect named php-apc package under Debians
   if ($title == 'apc') {
-    $package = $::php::params::php_apc_package_name
+    $package = "${::php::php_name}${::php::params::php_apc_package_suffix}"
   } else {
     # Hack to get pkg prefixes to work, i.e. php56-mcrypt title
     $package = $title ? {
       /^php/  => $title,
-      default => "${::php::params::php_package_name}-${title}"
+      default => "${::php::php_name}-${title}"
     }
   }
 

--- a/manifests/module/ini.pp
+++ b/manifests/module/ini.pp
@@ -30,13 +30,13 @@ define php::module::ini (
   # Handle naming issue of php-apc package on Debian
   if ($modname == 'apc' and $pkgname == false) {
     # Package name
-    $ospkgname = $::php::params::php_apc_package_name
+    $ospkgname = "${::php::php_name}${::php::params::php_apc_package_suffix}"
   } else {
     # Package name
     $ospkgname = $pkgname ? {
       /^php/  => "${pkgname}",
-      false   => "${::php::params::php_package_name}-${title}",
-      default => "${::php::params::php_package_name}-${pkgname}",
+      false   => "${::php::php_name}-${title}",
+      default => "${::php::php_name}-${pkgname}",
     }
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -2,9 +2,7 @@ class php::params {
   case $::osfamily {
     'Debian': {
       $php_package_name = 'php5'
-      $php_apc_package_name = 'php-apc'
-      $common_package_name = 'php5-common'
-      $cli_package_name = 'php5-cli'
+      $php_apc_package_suffix = '-apc'
       $php_conf_dir = '/etc/php5/conf.d'
       $fpm_package_name = 'php5-fpm'
       $fpm_service_name = 'php5-fpm'
@@ -18,9 +16,7 @@ class php::params {
     }
     default: {
       $php_package_name = 'php'
-      $php_apc_package_name = 'php-pecl-apc'
-      $common_package_name = 'php-common'
-      $cli_package_name = 'php-cli'
+      $php_apc_package_suffix = '-pecl-apc'
       $php_conf_dir = '/etc/php.d'
       $fpm_package_name = 'php-fpm'
       $fpm_service_name = 'php-fpm'
@@ -33,4 +29,7 @@ class php::params {
       $httpd_conf_dir = '/etc/httpd/conf.d'
     }
   }
+
+  $common_package_suffix = '-common'
+  $cli_package_suffix = '-cli'
 }

--- a/tests/cli.pp
+++ b/tests/cli.pp
@@ -1,2 +1,3 @@
+include php
 php::ini { '/etc/php.ini': }
 include php::cli

--- a/tests/fpm/conf.pp
+++ b/tests/fpm/conf.pp
@@ -1,3 +1,4 @@
+include php
 include php::fpm::daemon
 php::fpm::conf { 'www': ensure => absent }
 php::fpm::conf { 'customer1':

--- a/tests/fpm/daemon.pp
+++ b/tests/fpm/daemon.pp
@@ -1,1 +1,2 @@
+include php
 include php::fpm::daemon

--- a/tests/mod_php5.pp
+++ b/tests/mod_php5.pp
@@ -1,3 +1,4 @@
+include php
 php::ini { '/etc/php-httpd.ini': }
 service { 'httpd': }
 package { 'httpd': ensure => installed }

--- a/tests/module.pp
+++ b/tests/module.pp
@@ -1,1 +1,2 @@
+include php
 php::module { [ 'ldap', 'mcrypt', 'xml' ]: }


### PR DESCRIPTION
In order to install other version of php than OS provided, we need to
customize the php package name, e.g. php54, php56

To install customized version of php, install third party repo first,
e.g. IUS, then using

```
class { 'php': php_name => 'php54' }
```
