### PR TITLE
Use package pecl-memcache on RHEL

### DIFF
--- a/manifests/module.pp
+++ b/manifests/module.pp
@@ -14,10 +14,14 @@ define php::module (
 
   include '::php::params'
 
-  # Manage the incorrect named php-apc package under Debians
+  # Manage naming issue of pecl installed packages on RHEL
   if ($title == 'apc') {
     $package = $::php::params::php_apc_package_name
-  } else {
+  } 
+  if ($title == 'memcache') {
+    $package = $::php::params::php_memcache_package_name
+  } 
+  else {
     # Hack to get pkg prefixes to work, i.e. php56-mcrypt title
     $package = $title ? {
       /^php/  => $title,

--- a/manifests/module.pp
+++ b/manifests/module.pp
@@ -18,7 +18,7 @@ define php::module (
   if ($title == 'apc') {
     $package = $::php::params::php_apc_package_name
   } 
-  if ($title == 'memcache') {
+  elsif ($title == 'memcache') {
     $package = $::php::params::php_memcache_package_name
   } 
   else {

--- a/manifests/module/ini.pp
+++ b/manifests/module/ini.pp
@@ -27,11 +27,16 @@ define php::module::ini (
   # Strip 'pecl-*' prefix is present, since .ini files don't have it
   $modname = regsubst($title , '^pecl-', '', 'G')
 
-  # Handle naming issue of php-apc package on Debian
+  # Handle naming issue of pecl installed packages on RHEL
   if ($modname == 'apc' and $pkgname == false) {
     # Package name
     $ospkgname = $::php::params::php_apc_package_name
-  } else {
+  } 
+  elsif ($modname == 'memcache' and $pkgname == false) {
+    # Package name
+    $ospkgname = $::php::params::php_memcache_package_name
+  } 
+  else {
     # Package name
     $ospkgname = $pkgname ? {
       /^php/  => "${pkgname}",

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,6 +3,7 @@ class php::params {
     'Debian': {
       $php_package_name = 'php5'
       $php_apc_package_name = 'php-apc'
+      $php_memcache_package_name = 'php-memcache'
       $common_package_name = 'php5-common'
       $cli_package_name = 'php5-cli'
       $php_conf_dir = '/etc/php5/conf.d'
@@ -19,6 +20,7 @@ class php::params {
     default: {
       $php_package_name = 'php'
       $php_apc_package_name = 'php-pecl-apc'
+      $php_memcache_package_name = 'php-pecl-memcache'
       $common_package_name = 'php-common'
       $cli_package_name = 'php-cli'
       $php_conf_dir = '/etc/php.d'


### PR DESCRIPTION
When installing the memcache php module on RHEL, use the package 'php-pecl-memcache' in a similar way to the existing apc php module. 

**NOTE** if more of these exceptions to package names are encountered, it might be worth defining all module package names in a hash or array, to simplify the branching and `php::param` variables.