### PR TITLE
Systemd on-demand socket-based activation

### DIFF
--- a/manifests/fpm/systemd-daemon.pp
+++ b/manifests/fpm/systemd-daemon.pp
@@ -29,7 +29,7 @@ class php::fpm::systemd-daemon (
       ensure => 'directory',
       owner  => $owner,
       group  => $group_final,
-			mode	 => '0775',
+      mode	 => '0775',
     }
 
   }

--- a/manifests/fpm/systemd-daemon.pp
+++ b/manifests/fpm/systemd-daemon.pp
@@ -10,14 +10,14 @@ class php::fpm::systemd-daemon (
   $package_name                = $::php::params::fpm_package_name,
   $fpm_pool_dir                = $::php::params::fpm_pool_dir,
   $fpm_conf_dir                = $::php::params::fpm_conf_dir,
-  $log_owner                   = 'apache',
-  $log_group                   = 'apache',
+  $owner                   = 'apache',
+  $group                   = 'apache',
 ) inherits ::php::params {
 
   # Hack-ish to default to user for group too
-  $log_group_final = $log_group ? {
-    false   => $log_owner,
-    default => $log_group,
+  $group_final = $group ? {
+    false   => $owner,
+    default => $group,
   }
 
   package { $package_name: ensure => $ensure }
@@ -27,8 +27,8 @@ class php::fpm::systemd-daemon (
     # Create "/var/run/php-fpm/php-systemd/" as group-writable because the daemon does not start as root
     file { "/var/run/php-fpm/php-systemd/":
       ensure => 'directory',
-      owner  => $log_owner,
-      group  => $log_group_final,
+      owner  => $owner,
+      group  => $group_final,
 			mode	 => '0775',
     }
 

--- a/manifests/fpm/systemd-daemon.pp
+++ b/manifests/fpm/systemd-daemon.pp
@@ -23,6 +23,12 @@ class php::fpm::systemd-daemon (
   package { $package_name: ensure => $ensure }
 
   if ( $ensure != 'absent' ) {
+    file { "/var/run/php-fpm":
+      ensure => 'directory',
+      owner  => 'root',
+      group  => 'root',
+      mode   => '0775',
+    }
 
     # Create "/var/run/php-fpm/php-systemd/" as group-writable because the daemon does not start as root
     file { "/var/run/php-fpm/php-systemd/":

--- a/manifests/fpm/systemd-daemon.pp
+++ b/manifests/fpm/systemd-daemon.pp
@@ -1,0 +1,38 @@
+# Class: php::fpm::systemd-daemon
+#
+# Install the PHP FPM daemon. See php::fpm::systemd-socket-conf for configuring its pools.
+#
+# Sample Usage:
+#  include php::fpm::systemd-daemon
+#
+class php::fpm::systemd-daemon (
+  $ensure                      = 'present',
+  $package_name                = $::php::params::fpm_package_name,
+  $fpm_pool_dir                = $::php::params::fpm_pool_dir,
+  $fpm_conf_dir                = $::php::params::fpm_conf_dir,
+  $log_owner                   = 'apache',
+  $log_group                   = 'apache',
+) inherits ::php::params {
+
+  # Hack-ish to default to user for group too
+  $log_group_final = $log_group ? {
+    false   => $log_owner,
+    default => $log_group,
+  }
+
+  package { $package_name: ensure => $ensure }
+
+  if ( $ensure != 'absent' ) {
+
+    # Create "/var/run/php-fpm/php-systemd/" as group-writable because the daemon does not start as root
+    file { "/var/run/php-fpm/php-systemd/":
+      ensure => 'directory',
+      owner  => $log_owner,
+      group  => $log_group_final,
+			mode	 => '0775',
+    }
+
+  }
+
+}
+

--- a/manifests/fpm/systemd-socket-conf.pp
+++ b/manifests/fpm/systemd-socket-conf.pp
@@ -75,18 +75,8 @@ define php::fpm::systemd-socket-conf (
     default => $package_name,
   }
 
-  # The path to systemd/system varies
-  case $::osfamily {
-    'Debian': {
-      $service_path = '/lib/systemd/system'
-    }
-    default: {
-      $service_path = '/usr/lib/systemd/system'
-    }
-  }
-
   # Create systemd socket
-  file { "${service_path}/php-fpm-${pool}.socket":
+  file { "${systemd_service_path}/php-fpm-${pool}.socket":
     ensure  => $ensure,
     content => template('php/fpm/pool.socket.erb'),
     owner   => 'root',
@@ -100,13 +90,13 @@ define php::fpm::systemd-socket-conf (
   service { $socket_service_name:
     ensure    => running,
     enable    => true,
-    subscribe => File["${service_path}/php-fpm-${pool}.socket"],
-    require   => File["${service_path}/php-fpm-${pool}.service"],
+    subscribe => File["${systemd_service_path}/php-fpm-${pool}.socket"],
+    require   => File["${systemd_service_path}/php-fpm-${pool}.service"],
   }
 
   # Create per-pool service
   $systemd_service_name = "php-fpm-${pool}.service"
-  file { "${service_path}/php-fpm-${pool}.service":
+  file { "${systemd_service_path}/php-fpm-${pool}.service":
     ensure  => $ensure,
     content => template('php/fpm/pool.service.erb'),
     owner   => 'root',
@@ -117,7 +107,7 @@ define php::fpm::systemd-socket-conf (
   service { $systemd_service_name:
     enable    => true,
     subscribe => Service[$socket_service_name],
-    require   => File["${service_path}/php-fpm-${pool}.service"],
+    require   => File["${systemd_service_path}/php-fpm-${pool}.service"],
   }
 
   file { "${php::params::fpm_pool_dir}/${pool}.conf":

--- a/manifests/fpm/systemd-socket-conf.pp
+++ b/manifests/fpm/systemd-socket-conf.pp
@@ -82,7 +82,7 @@ define php::fpm::systemd-socket-conf (
     owner   => 'root',
     group   => 'root',
     mode    => '0644',
-    #require => Package[$fpm_package_name],
+    require => Package[$fpm_package_name],
   }
 
   $socket_service_name = "php-fpm-${pool}.socket"
@@ -95,14 +95,6 @@ define php::fpm::systemd-socket-conf (
   }
 
   # Create per-pool service
-
-  # Create "/var/run/php-fpm/php-systemd/" writable by $user because the daemon does not start as root
-  file { "/var/run/php-fpm/php-systemd/":
-    ensure => 'directory',
-    owner  => $user,
-    group  => $group,
-  }
-
   $systemd_service_name = "php-fpm-${pool}.service"
   file { "/usr/lib/systemd/system/php-fpm-${pool}.service":
     ensure  => $ensure,
@@ -110,7 +102,6 @@ define php::fpm::systemd-socket-conf (
     owner   => 'root',
     group   => 'root',
     mode    => '0644',
-    #require => Package[$fpm_package_name],
   }
 
   service { $systemd_service_name:
@@ -125,7 +116,6 @@ define php::fpm::systemd-socket-conf (
     owner   => 'root',
     group   => 'root',
     mode    => '0644',
-    #require => Package[$fpm_package_name],
     notify  => Service[$systemd_service_name],
   }
 

--- a/manifests/fpm/systemd-socket-conf.pp
+++ b/manifests/fpm/systemd-socket-conf.pp
@@ -112,7 +112,6 @@ define php::fpm::systemd-socket-conf (
   }
 
   service { $systemd_service_name:
-    ensure => running,
     enable => true,
   }
 

--- a/manifests/fpm/systemd-socket-conf.pp
+++ b/manifests/fpm/systemd-socket-conf.pp
@@ -60,6 +60,8 @@ define php::fpm::systemd-socket-conf (
   $php_admin_flag            = {},
   $php_directives            = [],
   $error_log                 = true,
+  $systemd_service_path      = $::php::params::systemd_service_path,
+  $fpm_binary                = $::php::params::fpm_binary,
 ) {
 
   include '::php::params'

--- a/manifests/fpm/systemd-socket-conf.pp
+++ b/manifests/fpm/systemd-socket-conf.pp
@@ -90,6 +90,9 @@ define php::fpm::systemd-socket-conf (
   service { $socket_service_name:
     ensure    => running,
     enable    => true,
+    start     => "systemctl start ${socket_service_name}",
+    stop      => "systemctl stop ${socket_service_name}",
+    status    => "systemctl status ${socket_service_name}",
     subscribe => File["${systemd_service_path}/php-fpm-${pool}.socket"],
     require   => File["${systemd_service_path}/php-fpm-${pool}.service"],
   }
@@ -106,6 +109,9 @@ define php::fpm::systemd-socket-conf (
 
   service { $systemd_service_name:
     enable    => true,
+    start     => "systemctl start ${systemd_service_name}",
+    stop      => "systemctl stop ${systemd_service_name}",
+    status    => "systemctl status $systemd_service_name}",
     subscribe => Service[$socket_service_name],
     require   => File["${systemd_service_path}/php-fpm-${pool}.service"],
   }

--- a/manifests/fpm/systemd-socket-conf.pp
+++ b/manifests/fpm/systemd-socket-conf.pp
@@ -88,8 +88,9 @@ define php::fpm::systemd-socket-conf (
   $socket_service_name = "php-fpm-${pool}.socket"
 
   service { $socket_service_name:
-    ensure => running,
-    enable => true,
+    ensure  => running,
+    enable  => true,
+    require => File["/usr/lib/systemd/system/php-fpm-${pool}.socket"],
   }
 
   # Create per-pool service
@@ -112,7 +113,9 @@ define php::fpm::systemd-socket-conf (
   }
 
   service { $systemd_service_name:
-    enable => true,
+    enable    => true,
+    subscribe => Service[$socket_service_name],
+    require   => File["/usr/lib/systemd/system/php-fpm-${pool}.service"],
   }
 
   file { "${php::params::fpm_pool_dir}/${pool}.conf":

--- a/manifests/fpm/systemd-socket-conf.pp
+++ b/manifests/fpm/systemd-socket-conf.pp
@@ -83,6 +83,7 @@ define php::fpm::systemd-socket-conf (
     default: {
       $service_path = '/usr/lib/systemd/system'
     }
+  }
 
   # Create systemd socket
   file { "${service_path}/php-fpm-${pool}.socket":

--- a/manifests/fpm/systemd-socket-conf.pp
+++ b/manifests/fpm/systemd-socket-conf.pp
@@ -88,10 +88,10 @@ define php::fpm::systemd-socket-conf (
   $socket_service_name = "php-fpm-${pool}.socket"
 
   service { $socket_service_name:
-    ensure  => running,
-    enable  => true,
-    require => File["/usr/lib/systemd/system/php-fpm-${pool}.socket"],
-    require => File["/usr/lib/systemd/system/php-fpm-${pool}.service"],
+    ensure    => running,
+    enable    => true,
+    subscribe => File["/usr/lib/systemd/system/php-fpm-${pool}.socket"],
+    require   => File["/usr/lib/systemd/system/php-fpm-${pool}.service"],
   }
 
   # Create per-pool service
@@ -117,7 +117,6 @@ define php::fpm::systemd-socket-conf (
     enable    => true,
     subscribe => Service[$socket_service_name],
     require   => File["/usr/lib/systemd/system/php-fpm-${pool}.service"],
-    require   => File["/usr/lib/systemd/system/php-fpm-${pool}.socket"],
   }
 
   file { "${php::params::fpm_pool_dir}/${pool}.conf":

--- a/manifests/fpm/systemd-socket-conf.pp
+++ b/manifests/fpm/systemd-socket-conf.pp
@@ -1,0 +1,127 @@
+# Define: php::fpm::systemd-socket-conf
+#
+# PHP FPM pool configuration definition. Note that the original php-fpm package
+# includes a pre-configured one called 'www' so you should either use that name
+# in order to override it, or "ensure => absent" it.
+#
+# Sample Usage:
+#  php::fpm::systemd-socket-conf { 'www': ensure => absent }
+#  php::fpm::systemd-socket-conf { 'customer1':
+#      listen      => '/var/run/php-fpm/customer1.socket',
+#      listen_port => 9001,
+#      user        => 'customer1',
+#  }
+#  php::fpm::systemd-socket-conf { 'customer2':
+#      listen      => '/var/run/php-fpm/customer1.socket',
+#      listen_port => 9002,
+#      user        => 'customer2',
+#  }
+#
+define php::fpm::systemd-socket-conf (
+  $ensure                    = 'present',
+  $package_name              = undef,
+  $service_name              = undef,
+  $user                      = 'apache',
+  $group                     = undef,
+  $listen                    = undef,
+  $listen_port               = '9000',
+  # Puppet does not allow dots in variable names
+  $listen_backlog            = '-1',
+  $listen_owner              = undef,
+  $listen_group              = undef,
+  $listen_mode               = undef,
+  $listen_allowed_clients    = '127.0.0.1',
+  $process_priority          = undef,
+  $pm                        = 'dynamic',
+  $pm_max_children           = '50',
+  $pm_start_servers          = '5',
+  $pm_min_spare_servers      = '5',
+  $pm_max_spare_servers      = '35',
+  $pm_process_idle_timeout   = undef,
+  $pm_max_requests           = '0',
+  $pm_status_path            = undef,
+  $ping_path                 = undef,
+  $ping_response             = 'pong',
+  $slowlog                   = "/var/log/php-fpm/${name}-slow.log",
+  $request_slowlog_timeout   = undef,
+  $request_terminate_timeout = undef,
+  $rlimit_files              = undef,
+  $rlimit_core               = undef,
+  $chroot                    = undef,
+  $chdir                     = undef,
+  $catch_workers_output      = 'no',
+  $security_limit_extensions = undef,
+  $env                       = [],
+  $env_value                 = {},
+  $php_value                 = {},
+  $php_flag                  = {},
+  $php_admin_value           = {},
+  $php_admin_flag            = {},
+  $php_directives            = [],
+  $error_log                 = true,
+) {
+
+  include '::php::params'
+
+  $pool = $title
+
+  # Create systemd socket
+  file { "/usr/lib/systemd/system/php-fpm-${pool}.socket":
+    ensure  => $ensure,
+    content => template('php/fpm/pool.socket.erb'),
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    require => Package[$fpm_package_name],
+  }
+
+  service { "php-fpm-${pool}.socket":
+    ensure => running,
+    start  => 'systemctl start php-fpm-${pool}.socket',
+    stop   => 'systemctl stop php-fpm-${pool}.socket',
+    status => 'systemctl status php-fpm-${pool}.socket',
+  }
+
+  # Create per-pool service
+  $service_name = 'php-fpm-${pool}.service'
+  file { "/usr/lib/systemd/system/php-fpm-${pool}.service":
+    ensure  => $ensure,
+    content => template('php/fpm/pool.service.erb'),
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    require => Package[$fpm_package_name],
+  }
+
+  service { "${service_name}":
+    ensure => running,
+    start  => 'systemctl start php-fpm-${pool}.service',
+    stop   => 'systemctl stop php-fpm-${pool}.service',
+    status => 'systemctl status php-fpm-${pool}.service',
+  }
+
+  # Hack-ish to default to user for group too
+  $group_final = $group ? { undef => $user, default => $group }
+
+  # This is much easier from classes which inherit params...
+  $fpm_package_name = $package_name ? {
+    undef   => $::php::params::fpm_package_name,
+    default => $package_name,
+  }
+  $fpm_service_name = $service_name ? {
+    undef   => $::php::params::fpm_service_name,
+    default => $service_name,
+  }
+
+  file { "${php::params::fpm_pool_dir}/${pool}.conf":
+    ensure  => $ensure,
+    content => template('php/fpm/pool-systemd.conf.erb'),
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    require => Package[$fpm_package_name],
+    notify  => Service[$fpm_service_name],
+  }
+
+}
+

--- a/manifests/fpm/systemd-socket-conf.pp
+++ b/manifests/fpm/systemd-socket-conf.pp
@@ -62,6 +62,7 @@ define php::fpm::systemd-socket-conf (
   $error_log                 = true,
   $systemd_service_path      = $::php::params::systemd_service_path,
   $fpm_binary                = $::php::params::fpm_binary,
+  $fpm_pool_dir              = $::php::params::fpm_pool_dir,
 ) {
 
   include '::php::params'
@@ -118,7 +119,7 @@ define php::fpm::systemd-socket-conf (
     require   => File["${systemd_service_path}/php-fpm-${pool}.service"],
   }
 
-  file { "${php::params::fpm_pool_dir}/${pool}.conf":
+  file { "${fpm_pool_dir}/${pool}.conf":
     ensure  => $ensure,
     content => template('php/fpm/pool-systemd.conf.erb'),
     owner   => 'root',

--- a/manifests/fpm/systemd-socket-conf.pp
+++ b/manifests/fpm/systemd-socket-conf.pp
@@ -91,6 +91,7 @@ define php::fpm::systemd-socket-conf (
     ensure  => running,
     enable  => true,
     require => File["/usr/lib/systemd/system/php-fpm-${pool}.socket"],
+    require => File["/usr/lib/systemd/system/php-fpm-${pool}.service"],
   }
 
   # Create per-pool service
@@ -116,6 +117,7 @@ define php::fpm::systemd-socket-conf (
     enable    => true,
     subscribe => Service[$socket_service_name],
     require   => File["/usr/lib/systemd/system/php-fpm-${pool}.service"],
+    require   => File["/usr/lib/systemd/system/php-fpm-${pool}.socket"],
   }
 
   file { "${php::params::fpm_pool_dir}/${pool}.conf":

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,6 +19,8 @@ class php::params {
       $httpd_package_name = 'apache2'
       $httpd_service_name = 'apache2'
       $httpd_conf_dir = '/etc/apache2/conf.d'
+      $systemd_service_path = '/lib/systemd/system'
+      $binary = '/usr/sbin/php5-fpm'
     }
     default: {
       $php_package_name = 'php'
@@ -37,6 +39,8 @@ class php::params {
       $httpd_package_name = 'httpd'
       $httpd_service_name = 'httpd'
       $httpd_conf_dir = '/etc/httpd/conf.d'
+      $systemd_service_path = '/usr/lib/systemd/system'
+      $binary = '/sbin/php-fpm'
     }
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -20,7 +20,7 @@ class php::params {
       $httpd_service_name = 'apache2'
       $httpd_conf_dir = '/etc/apache2/conf.d'
       $systemd_service_path = '/lib/systemd/system'
-      $binary = '/usr/sbin/php5-fpm'
+      $fpm_binary = '/usr/sbin/php5-fpm'
     }
     default: {
       $php_package_name = 'php'
@@ -40,7 +40,7 @@ class php::params {
       $httpd_service_name = 'httpd'
       $httpd_conf_dir = '/etc/httpd/conf.d'
       $systemd_service_path = '/usr/lib/systemd/system'
-      $binary = '/sbin/php-fpm'
+      $fpm_binary = '/sbin/php-fpm'
     }
   }
 }

--- a/templates/fpm/pool-systemd.conf.erb
+++ b/templates/fpm/pool-systemd.conf.erb
@@ -1,0 +1,305 @@
+[global]
+pid = /var/run/php-fpm/<%= @pool %>.pid
+error_log = syslog
+daemonize = no
+
+; Start a new pool named '<%= @pool %>'.
+[<%= @pool %>]
+
+; The address on which to accept FastCGI requests.
+; Valid syntaxes are:
+;   'ip.add.re.ss:port'    - to listen on a TCP socket to a specific address on
+;                            a specific port;
+;   'port'                 - to listen on a TCP socket to all addresses on a
+;                            specific port;
+;   '/path/to/unix/socket' - to listen on a unix socket.
+; Note: This value is mandatory.
+listen = /var/run/php-fpm/<%= @pool %>.socket
+
+; Set listen(2) backlog. A value of '-1' means unlimited.
+; Default Value: -1
+listen.backlog = <%= @listen_backlog %>
+
+; List of ipv4 addresses of FastCGI clients which are allowed to connect.
+; Equivalent to the FCGI_WEB_SERVER_ADDRS environment variable in the original
+; PHP FCGI (5.2.2+). Makes sense only with a tcp listening socket. Each address
+; must be separated by a comma. If this value is left blank, connections will be
+; accepted from any ip address.
+; Default Value: any
+<% if @listen_allowed_clients == 'any' -%>
+;listen.allowed_clients =
+<% else -%>
+listen.allowed_clients = <%= @listen_allowed_clients %>
+<% end -%>
+
+; Set permissions for unix socket, if one is used. In Linux, read/write
+; permissions must be set in order to allow connections from a web server. Many
+; BSD-derived systems allow connections regardless of permissions. 
+; Default Values: user and group are set as the running user
+;                 mode is set to 0660
+<% if @listen_owner -%>
+listen.owner = <%= @listen_owner %>
+<% else -%>
+;listen.owner = nobody
+<% end -%>
+<% if @listen_group -%>
+listen.group = <%= @listen_group %>
+<% else -%>
+;listen.group = nobody
+<% end -%>
+<% if @listen_mode -%>
+listen.mode = <%= @listen_mode %>
+<% else -%>
+;listen.mode = 0666
+<% end -%>
+
+; Unix user/group of processes
+; Note: The user is mandatory. If the group is not set, the default user's group
+;       will be used.
+; RPM: apache Choosed to be able to access some dir as httpd
+user = <%= @user %>
+; RPM: Keep a group allowed to write in log dir.
+group = <%= @group_final %>
+
+; Choose how the process manager will control the number of child processes.
+; Possible Values:
+;   static  - a fixed number (pm.max_children) of child processes;
+;   dynamic - the number of child processes are set dynamically based on the
+;             following directives:
+;             pm.max_children      - the maximum number of children that can
+;                                    be alive at the same time.
+;             pm.start_servers     - the number of children created on startup.
+;             pm.min_spare_servers - the minimum number of children in 'idle'
+;                                    state (waiting to process). If the number
+;                                    of 'idle' processes is less than this
+;                                    number then some children will be created.
+;             pm.max_spare_servers - the maximum number of children in 'idle'
+;                                    state (waiting to process). If the number
+;                                    of 'idle' processes is greater than this
+;                                    number then some children will be killed.
+; Note: This value is mandatory.
+pm = <%= @pm %>
+
+; The number of child processes to be created when pm is set to 'static' and the
+; maximum number of child processes to be created when pm is set to 'dynamic'.
+; This value sets the limit on the number of simultaneous requests that will be
+; served. Equivalent to the ApacheMaxClients directive with mpm_prefork.
+; Equivalent to the PHP_FCGI_CHILDREN environment variable in the original PHP
+; CGI.
+; Note: Used when pm is set to either 'static' or 'dynamic'
+; Note: This value is mandatory.
+pm.max_children = <%= @pm_max_children %>
+
+; The number of child processes created on startup.
+; Note: Used only when pm is set to 'dynamic'
+; Default Value: min_spare_servers + (max_spare_servers - min_spare_servers) / 2
+pm.start_servers = <%= @pm_start_servers %>
+
+; The desired minimum number of idle server processes.
+; Note: Used only when pm is set to 'dynamic'
+; Note: Mandatory when pm is set to 'dynamic'
+pm.min_spare_servers = <%= @pm_min_spare_servers %>
+
+; The desired maximum number of idle server processes.
+; Note: Used only when pm is set to 'dynamic'
+; Note: Mandatory when pm is set to 'dynamic'
+pm.max_spare_servers = <%= @pm_max_spare_servers %>
+ 
+; The number of requests each child process should execute before respawning.
+; This can be useful to work around memory leaks in 3rd party libraries. For
+; endless request processing specify '0'. Equivalent to PHP_FCGI_MAX_REQUESTS.
+; Default Value: 0
+pm.max_requests = <%= @pm_max_requests %>
+
+; The URI to view the FPM status page. If this value is not set, no URI will be
+; recognized as a status page. By default, the status page shows the following
+; information:
+;   accepted conn    - the number of request accepted by the pool;
+;   pool             - the name of the pool;
+;   process manager  - static or dynamic;
+;   idle processes   - the number of idle processes;
+;   active processes - the number of active processes;
+;   total processes  - the number of idle + active processes.
+; The values of 'idle processes', 'active processes' and 'total processes' are
+; updated each second. The value of 'accepted conn' is updated in real time.
+; Example output:
+;   accepted conn:   12073
+;   pool:             www
+;   process manager:  static
+;   idle processes:   35
+;   active processes: 65
+;   total processes:  100
+; By default the status page output is formatted as text/plain. Passing either
+; 'html' or 'json' as a query string will return the corresponding output
+; syntax. Example:
+;   http://www.foo.bar/status
+;   http://www.foo.bar/status?json
+;   http://www.foo.bar/status?html
+; Note: The value must start with a leading slash (/). The value can be
+;       anything, but it may not be a good idea to use the .php extension or it
+;       may conflict with a real PHP file.
+; Default Value: not set 
+<% if @pm_status_path -%>
+pm.status_path = <%= @pm_status_path %>
+<% else -%>
+;pm.status_path = /status
+<% end -%>
+ 
+; The ping URI to call the monitoring page of FPM. If this value is not set, no
+; URI will be recognized as a ping page. This could be used to test from outside
+; that FPM is alive and responding, or to
+; - create a graph of FPM availability (rrd or such);
+; - remove a server from a group if it is not responding (load balancing);
+; - trigger alerts for the operating team (24/7).
+; Note: The value must start with a leading slash (/). The value can be
+;       anything, but it may not be a good idea to use the .php extension or it
+;       may conflict with a real PHP file.
+; Default Value: not set
+<% if @ping_path -%>
+ping.path = <%= @ping_path %>
+<% else -%>
+;ping.path = /ping
+<% end -%>
+
+; This directive may be used to customize the response of a ping request. The
+; response is formatted as text/plain with a 200 response code.
+; Default Value: pong
+ping.response = <%= @ping_response %>
+ 
+; The timeout for serving a single request after which the worker process will
+; be killed. This option should be used when the 'max_execution_time' ini option
+; does not stop script execution for some reason. A value of '0' means 'off'.
+; Available units: s(econds)(default), m(inutes), h(ours), or d(ays)
+; Default Value: 0
+<% if @request_terminate_timeout -%>
+request_terminate_timeout = <%= @request_terminate_timeout %>
+<% else -%>
+;request_terminate_timeout = 0
+<% end -%>
+ 
+; The timeout for serving a single request after which a PHP backtrace will be
+; dumped to the 'slowlog' file. A value of '0s' means 'off'.
+; Available units: s(econds)(default), m(inutes), h(ours), or d(ays)
+; Default Value: 0
+<% if @request_slowlog_timeout -%>
+request_slowlog_timeout = <%= @request_slowlog_timeout %>
+<% else -%>
+;request_slowlog_timeout = 0
+<% end -%>
+ 
+; The log file for slow requests
+; Default Value: not set
+; Note: slowlog is mandatory if request_slowlog_timeout is set
+slowlog = <%= @slowlog %>
+ 
+; Set open file descriptor rlimit.
+; Default Value: system defined value
+<% if @rlimit_files -%>
+rlimit_files = <%= @rlimit_files %>
+<% else -%>
+;rlimit_files = 1024
+<% end -%>
+ 
+; Set max core size rlimit.
+; Possible Values: 'unlimited' or an integer greater or equal to 0
+; Default Value: system defined value
+<% if @rlimit_core -%>
+rlimit_core = <%= @rlimit_core %>
+<% else -%>
+;rlimit_core = 0
+<% end -%>
+ 
+; Chroot to this directory at the start. This value must be defined as an
+; absolute path. When this value is not set, chroot is not used.
+; Note: chrooting is a great security feature and should be used whenever 
+;       possible. However, all PHP paths will be relative to the chroot
+;       (error_log, sessions.save_path, ...).
+; Default Value: not set
+<% if @chroot -%>
+chroot = <%= @chroot %>
+<% else -%>
+;chroot = 
+<% end -%>
+ 
+; Chdir to this directory at the start. This value must be an absolute path.
+; Default Value: current directory or / when chroot
+<% if @chdir -%>
+chdir = <%= @chdir %>
+<% else -%>
+;chdir = /var/www
+<% end -%>
+ 
+; Redirect worker stdout and stderr into main error log. If not set, stdout and
+; stderr will be redirected to /dev/null according to FastCGI specs.
+; Default Value: no
+catch_workers_output = <%= @catch_workers_output %>
+ 
+; Limits the extensions of the main script FPM will allow to parse. This can
+; prevent configuration mistakes on the web server side. You should only limit
+; FPM to .php extensions to prevent malicious users to use other extensions to
+; exectute php code.
+; Note: set an empty value to allow all extensions.
+; Default Value: .php
+<% if @security_limit_extensions -%>
+security.limit_extensions = <%= @security_limit_extensions %>
+<% else -%>
+;security.limit_extensions = .php .php3 .php4 .php5
+<% end -%>
+
+; Pass environment variables like LD_LIBRARY_PATH. All $VARIABLEs are taken from
+; the current environment.
+; Default Value: clean env
+;env[HOSTNAME] = $HOSTNAME
+;env[PATH] = /usr/local/bin:/usr/bin:/bin
+;env[TMP] = /tmp
+;env[TMPDIR] = /tmp
+;env[TEMP] = /tmp
+<% @env.each do |var| -%>
+env[<%= var %>] = $<%= var %>
+<% end -%>
+<% @env_value.sort_by {|key,value| key}.each do |key,value| -%>
+env[<%= key %>] = <%= value %>
+<% end -%>
+
+; Additional php.ini defines, specific to this pool of workers. These settings
+; overwrite the values previously defined in the php.ini. The directives are the
+; same as the PHP SAPI:
+;   php_value/php_flag             - you can set classic ini defines which can
+;                                    be overwritten from PHP call 'ini_set'. 
+;   php_admin_value/php_admin_flag - these directives won't be overwritten by
+;                                     PHP call 'ini_set'
+; For php_*flag, valid values are on, off, 1, 0, true, false, yes or no.
+
+; Defining 'extension' will load the corresponding shared extension from
+; extension_dir. Defining 'disable_functions' or 'disable_classes' will not
+; overwrite previously defined php.ini values, but will append the new value
+; instead.
+
+; Default Value: nothing is defined by default except the values in php.ini and
+;                specified at startup with the -d argument
+;php_admin_value[sendmail_path] = /usr/sbin/sendmail -t -i -f www@my.domain.com
+;php_flag[display_errors] = off
+;php_admin_value[memory_limit] = 128M
+<% if @error_log == true -%>
+php_admin_value[error_log] = /var/log/php-fpm/<%= @pool %>-error.log
+php_admin_flag[log_errors] = on
+<% elsif @error_log and !@error_log.empty? -%>
+php_admin_value[error_log] = <%= @error_log %>
+php_admin_flag[log_errors] = on
+<% end -%>
+<% @php_value.sort_by {|key,value| key}.each do |key,value| -%>
+php_value[<%= key %>] = <%= value %>
+<% end -%>
+<% @php_flag.sort_by {|key,flag| key}.each do |key,flag| -%>
+php_flag[<%= key %>] = <%= flag %>
+<% end -%>
+<% @php_admin_value.sort_by {|key,value| key}.each do |key,value| -%>
+php_admin_value[<%= key %>] = <%= value %>
+<% end -%>
+<% @php_admin_flag.sort_by {|key,flag| key}.each do |key,flag| -%>
+php_admin_flag[<%= key %>] = <%= flag %>
+<% end -%>
+<% @php_directives.each do |line| -%>
+<%= line %>
+<% end -%>
+

--- a/templates/fpm/pool-systemd.conf.erb
+++ b/templates/fpm/pool-systemd.conf.erb
@@ -1,5 +1,5 @@
 [global]
-pid = /var/run/php-fpm/<%= @pool %>.pid
+pid = /var/run/php-fpm/php-systemd/<%= @pool %>.pid
 error_log = syslog
 daemonize = no
 

--- a/templates/fpm/pool.service.erb
+++ b/templates/fpm/pool.service.erb
@@ -1,5 +1,5 @@
 [Service]
-ExecStart=<%= @fpm_binary %> --fpm-config=<%=fpm_pool_dir %>/<%= @pool %>.conf
+ExecStart=<%= @fpm_binary %> --fpm-config=<%= @fpm_pool_dir %>/<%= @pool %>.conf
 User=<%= @user %>
 Group=<%= @group %>
 Environment="FPM_SOCKETS=/var/run/php-fpm/<%= @pool %>.socket=3"

--- a/templates/fpm/pool.service.erb
+++ b/templates/fpm/pool.service.erb
@@ -1,5 +1,5 @@
 [Service]
-ExecStart=<%= @binary %> --fpm-config=/etc/php-fpm.d/<%= @pool %>.conf
+ExecStart=<%= @fpm_binary %> --fpm-config=/etc/php-fpm.d/<%= @pool %>.conf
 User=<%= @user %>
 Group=<%= @group %>
 Environment="FPM_SOCKETS=/var/run/php-fpm/<%= @pool %>.socket=3"

--- a/templates/fpm/pool.service.erb
+++ b/templates/fpm/pool.service.erb
@@ -1,5 +1,5 @@
 [Service]
-ExecStart=<%= @fpm_binary %> --fpm-config=/etc/php-fpm.d/<%= @pool %>.conf
+ExecStart=<%= @fpm_binary %> --fpm-config=<%=fpm_pool_dir %>/<%= @pool %>.conf
 User=<%= @user %>
 Group=<%= @group %>
 Environment="FPM_SOCKETS=/var/run/php-fpm/<%= @pool %>.socket=3"

--- a/templates/fpm/pool.service.erb
+++ b/templates/fpm/pool.service.erb
@@ -1,5 +1,5 @@
 [Service]
-ExecStart=/sbin/php-fpm --fpm-config=/etc/php-fpm.d/<%= @pool %>.conf
+ExecStart=<%= @binary %> --fpm-config=/etc/php-fpm.d/<%= @pool %>.conf
 User=<%= @user %>
 Group=<%= @group %>
 Environment="FPM_SOCKETS=/var/run/php-fpm/<%= @pool %>.socket=3"

--- a/templates/fpm/pool.service.erb
+++ b/templates/fpm/pool.service.erb
@@ -1,0 +1,5 @@
+[Service]
+ExecStart=/sbin/php-fpm --fpm-config=/etc/php-fpm.d/<%= @pool %>.conf
+User=<%= @user %>
+Group=<%= @group %>
+Environment="FPM_SOCKETS=/var/run/php-fpm/<%= @pool %>.socket=3"

--- a/templates/fpm/pool.socket.erb
+++ b/templates/fpm/pool.socket.erb
@@ -1,5 +1,9 @@
 [Socket]
+<% if @listen_address %>
+ListenStream=<%= @listen_address %>:<%= @listen_port %>
+<% else %>
 ListenStream=<%= @listen_port %>
+<% end %>
 
 [Install]
 WantedBy=sockets.target

--- a/templates/fpm/pool.socket.erb
+++ b/templates/fpm/pool.socket.erb
@@ -1,0 +1,5 @@
+[Socket]
+ListenStream=<%= @listen_port %>
+
+[Install]
+WantedBy=sockets.target


### PR DESCRIPTION
Provides support for creating systemd socket-based activation of on-demand PHP-FPM daemons.

Defines `php::fpm::systemd-socket-conf` that will create the corresponding systemd `.socket` and `.service` configurations.  Multiple pools may be created using separate sockets/services so that rolling, zero-downtime restarts of PHP-FPM may be accomplished.

Tested on CentOS7 and Debian Jessie.

Based heavily on http://thanatos.be/2014/04/12/php-fpm-ondemand.html

