### PR TITLE
Added pcre_jit parameter

### DIFF
--- a/manifests/ini.pp
+++ b/manifests/ini.pp
@@ -82,6 +82,7 @@ define php::ini (
   $default_socket_timeout          = '60',
   $date_timezone                   = undef,
   $pcre_backtrack_limit            = undef,
+  $pcre_jit                        = undef,
   $pcre_recursion_limit            = undef,
   $phar_readonly                   = undef,
   $sendmail_path                   = '/usr/sbin/sendmail -t -i',

--- a/templates/php.ini-el6.erb
+++ b/templates/php.ini-el6.erb
@@ -1029,6 +1029,13 @@ date.timezone = <%= @date_timezone %>
 ;sqlite3.extension_dir =
 
 [Pcre]
+;PCRE Whether PCRE's just-in-time compilation is going to be used. 
+;Available since PHP 7.0.0, default value "1"
+; https://www.php.net/manual/en/pcre.configuration.php#ini.pcre.jit
+<% if @pcre_jit -%>
+pcre.jit = <%= @pcre_jit %>
+<% end -%>
+
 ;PCRE library backtracking limit.
 ; http://www.php.net/manual/en/pcre.configuration.php#ini.pcre.backtrack-limit
 <% if @pcre_backtrack_limit -%>


### PR DESCRIPTION
Added pcre_jit parameter.

PCRE Whether PCRE's just-in-time compilation is going to be used.
Available since PHP 7.0.0., default value "1"

Source: https://www.php.net/manual/en/pcre.configuration.php#ini.pcre.jit



